### PR TITLE
XAL: Implement tokenstore, gssv api fixes, enhance examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Cargo.lock
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+# Tokens
+tokens.json

--- a/gamestreaming_webrtc/Cargo.toml
+++ b/gamestreaming_webrtc/Cargo.toml
@@ -17,6 +17,7 @@ chrono = "0.4.22"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full"]}
+xal = { path = "../xal" }
 
 [[example]]
 name = "webrtc-client"

--- a/gamestreaming_webrtc/examples/client.rs
+++ b/gamestreaming_webrtc/examples/client.rs
@@ -1,29 +1,24 @@
 use gamestreaming_webrtc::{GamestreamingClient, Platform};
-use std::io;
+use xal::utils::TokenStore;
+
+const TOKENS_FILEPATH: &str = "tokens.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!(
-        r#"!!! ACTION REQUIRED !!!
-Paste the GSSV Token and hit [ENTER]"#
-    );
+    let ts = match TokenStore::load(TOKENS_FILEPATH) {
+        Ok(ts) => ts,
+        Err(err) => {
+            println!("Failed to load tokens!");
+            return Err(err);
+        }
+    };
 
-    let mut gssv_token = String::new();
-    let _ = io::stdin().read_line(&mut gssv_token)?;
-    // Strip newline
-    let gssv_token = gssv_token.strip_suffix('\n').unwrap();
-
-    println!(
-        r#"!!! ACTION REQUIRED !!!
-Paste the XCloud Transfer Token and hit [ENTER]"#
-    );
-
-    let mut xcloud_transfer_token = String::new();
-    let _ = io::stdin().read_line(&mut xcloud_transfer_token)?;
-    // Strip newline
-    let xcloud_transfer_token = xcloud_transfer_token.strip_suffix('\n').unwrap();
-
-    let _ = GamestreamingClient::create(Platform::Cloud, gssv_token, xcloud_transfer_token).await?;
+    let _ = GamestreamingClient::create(
+        Platform::Cloud,
+        &ts.gssv_token.token_data.token,
+        &ts.xcloud_transfer_token.lpt,
+    )
+    .await?;
 
     todo!("Implement client");
 }

--- a/gamestreaming_webrtc/examples/client.rs
+++ b/gamestreaming_webrtc/examples/client.rs
@@ -13,12 +13,25 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    let _ = GamestreamingClient::create(
+    let xcloud = GamestreamingClient::create(
         Platform::Cloud,
         &ts.gssv_token.token_data.token,
         &ts.xcloud_transfer_token.lpt,
     )
     .await?;
+
+    match xcloud.lookup_games().await?.first() {
+        Some(title) => {
+            println!("Starting title: {:?}", title);
+            println!(
+                "Session started successfully: {:?}",
+                xcloud.start_stream_xcloud(&title.title_id).await?
+            );
+        }
+        None => {
+            return Err("No titles received from API".into());
+        }
+    }
 
     todo!("Implement client");
 }

--- a/gamestreaming_webrtc/examples/gssv_api.rs
+++ b/gamestreaming_webrtc/examples/gssv_api.rs
@@ -15,10 +15,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     println!("Logging in");
     let home_api = GssvApi::login_xhome(&ts.gssv_token.token_data.token).await?;
-
     println!("Fetching consoles");
-    let resp = home_api.get_consoles().await?;
-    println!("{:?}", resp);
+    println!("{:?}", home_api.get_consoles().await);
+
+    let xcloud_api = GssvApi::login_xcloud(&ts.gssv_token.token_data.token).await?;
+    println!("Fetching titles");
+    println!("{:?}", xcloud_api.get_titles().await);
 
     Ok(())
 }

--- a/gamestreaming_webrtc/examples/gssv_api.rs
+++ b/gamestreaming_webrtc/examples/gssv_api.rs
@@ -1,21 +1,20 @@
 use gamestreaming_webrtc::api::GssvApi;
-use std::io;
+use xal::utils::TokenStore;
+
+const TOKENS_FILEPATH: &str = "tokens.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    println!(
-        r#"!!! ACTION REQUIRED !!!
-Paste the GSSV Token and hit [ENTER]"#
-    );
-
-    let mut gssv_token = String::new();
-    let _ = io::stdin().read_line(&mut gssv_token)?;
-
-    // Strip newline
-    let gssv_token = gssv_token.strip_suffix('\n').unwrap();
+    let ts = match TokenStore::load(TOKENS_FILEPATH) {
+        Ok(ts) => ts,
+        Err(err) => {
+            println!("Failed to load tokens!");
+            return Err(err);
+        }
+    };
 
     println!("Logging in");
-    let home_api = GssvApi::login_xhome(gssv_token).await?;
+    let home_api = GssvApi::login_xhome(&ts.gssv_token.token_data.token).await?;
 
     println!("Fetching consoles");
     let resp = home_api.get_consoles().await?;

--- a/gamestreaming_webrtc/src/api.rs
+++ b/gamestreaming_webrtc/src/api.rs
@@ -601,14 +601,14 @@ pub struct TitleTab {
 #[serde(rename_all = "camelCase")]
 pub struct TitleDetails {
     pub product_id: String,
-    pub xbox_title_id: String,
+    pub xbox_title_id: u32,
     pub has_entitlement: bool,
     pub blocked_by_family_safety: bool,
     pub supports_in_app_purchases: bool,
-    pub supported_tabs: Option<TitleTab>,
+    pub supported_tabs: Option<Vec<TitleTab>>,
     pub native_touch: bool,
     pub opt_out_of_default_layout_touch_controls: bool,
-    pub programs: Vec<String>,
+    pub programs: Option<Vec<String>>,
     pub is_free_in_store: bool,
 }
 

--- a/xal/examples/sisu_auth.rs
+++ b/xal/examples/sisu_auth.rs
@@ -2,10 +2,18 @@ use std::io;
 use url::Url;
 use xal::authenticator::XalAuthenticator;
 use xal::oauth2::PkceCodeVerifier;
+use xal::utils::TokenStore;
+
+const TOKENS_FILEPATH: &str = "tokens.json";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut xal = XalAuthenticator::default();
+
+    if let Ok(ts) = TokenStore::load("tokens.json") {
+        todo!("TODO: Refresh tokens -> {:?}", ts)
+    }
+
     let (code_challenge, code_verifier) = XalAuthenticator::get_code_challenge();
 
     println!("Getting device token...");
@@ -108,6 +116,14 @@ When finished, paste the Redirect URL and hit [ENTER]"#,
             )
             .await?;
         println!("Transfer token={:?}", transfer_token);
+
+        let ts = TokenStore {
+            //wl_token,
+            sisu_tokens: auth_response,
+            gssv_token,
+            xcloud_transfer_token: transfer_token,
+        };
+        ts.save(TOKENS_FILEPATH)?
     } else {
         println!("No authorization code fetched :(");
     }

--- a/xal/src/authenticator.rs
+++ b/xal/src/authenticator.rs
@@ -27,7 +27,7 @@ use uuid;
 type Error = Box<dyn std::error::Error>;
 type Result<T> = std::result::Result<T, Error>;
 
-type SpecialTokenResponse = WindowsLiveTokenResponse<EmptyExtraTokenFields>;
+pub type SpecialTokenResponse = WindowsLiveTokenResponse<EmptyExtraTokenFields>;
 type SpecialClient = OAuthClient<
     BasicErrorResponse,
     SpecialTokenResponse,

--- a/xal/src/lib.rs
+++ b/xal/src/lib.rs
@@ -6,3 +6,4 @@ pub mod authenticator;
 pub mod filetime;
 pub mod models;
 pub mod request_signer;
+pub mod utils;

--- a/xal/src/utils.rs
+++ b/xal/src/utils.rs
@@ -1,0 +1,29 @@
+use serde::{Deserialize, Serialize};
+use std::fs;
+
+use crate::models::response::{SisuAuthorizationResponse, XCloudTokenResponse, XSTSResponse};
+// use crate::authenticator::SpecialTokenResponse;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct TokenStore {
+    // FIXME: Understand lifetimes... and probably get rid of 'static lifetime
+    // on XalClientParameters
+    // Finally: De-/serialize XalClientParameters
+    // pub client_params: XalClientParameters,
+    // pub wl_token: SpecialTokenResponse,
+    pub sisu_tokens: SisuAuthorizationResponse,
+    pub gssv_token: XSTSResponse,
+    pub xcloud_transfer_token: XCloudTokenResponse,
+}
+
+impl TokenStore {
+    pub fn load(filepath: &str) -> Result<Self, Box<dyn std::error::Error>> {
+        let s = fs::read_to_string(filepath)?;
+        serde_json::from_str(&s).map_err(|e| e.into())
+    }
+
+    pub fn save(&self, filepath: &str) -> Result<(), Box<dyn std::error::Error>> {
+        let s = serde_json::to_string_pretty(self)?;
+        fs::write(filepath, s).map_err(|e| e.into())
+    }
+}


### PR DESCRIPTION
- XAL: implement TokenStore
- XAL: Use TokenStore in examples (instead of taken tokens via cmdline)
- GSSV API: Fix get_titles / TitleDetails schema
- Examples: Fetch titles, attempt starting game session